### PR TITLE
Fix privilege typo in blog post

### DIFF
--- a/public/articles/a-tech-retrospective/index.md
+++ b/public/articles/a-tech-retrospective/index.md
@@ -11,7 +11,7 @@ In terms of what's next, I'm joining Iterate - [https://www.iterate.com/](https:
 
 ## Looking Back
 
-Over the nearly decade at Wakelet, I've made many tech decisions - some good, some bad. More importantly, I have the somewhat unique experience of coming face-to-face with some of my technology decisions years later. I have the privilige of seeing the day 1 AND the day 3000 experience for some of these things!
+Over the nearly decade at Wakelet, I've made many tech decisions - some good, some bad. More importantly, I have the somewhat unique experience of coming face-to-face with some of my technology decisions years later. I have the privilege of seeing the day 1 AND the day 3000 experience for some of these things!
 
 So, without further ado, here's a tech retrospective of my time at Wakelet.
 


### PR DESCRIPTION
## Summary
- fix spelling of "privilege" in retrospective post

## Testing
- `npm run lint` *(fails: invalid option `--ignore-path`)*
- `npm run typecheck` *(fails: cannot find module './me.jpg', etc.)*

------
https://chatgpt.com/codex/tasks/task_b_685f17df69bc832cb192f24125f8ff27